### PR TITLE
Added an option to always show the infobox

### DIFF
--- a/src/main/java/com/specoverlay/SpecOverlayConfig.java
+++ b/src/main/java/com/specoverlay/SpecOverlayConfig.java
@@ -7,7 +7,7 @@ import net.runelite.client.config.ConfigItem;
 @ConfigGroup("SpecOverlay")
 public interface SpecOverlayConfig extends Config {
     enum OverlayType {
-        INFOBOX("InfoBox"), OVERLAY("Overlay");
+        INFOBOX("InfoBox"), OVERLAY("Overlay"),ALWAYS("Always");
         private final String name;
 
         OverlayType(String string) {

--- a/src/main/java/com/specoverlay/SpecOverlayPlugin.java
+++ b/src/main/java/com/specoverlay/SpecOverlayPlugin.java
@@ -80,6 +80,12 @@ public class SpecOverlayPlugin extends Plugin {
                 overlayManager.remove(specOverlayOverlay);
             }
         }
+        if (specOverlayConfig.info() == SpecOverlayConfig.OverlayType.ALWAYS) {
+            specOverlayCounter.setImage(spriteManager.getSprite(SpriteID.MINIMAP_ORB_SPECIAL_ICON, 0));
+            if (!infoBoxManager.getInfoBoxes().contains(specOverlayCounter)) { //I genuinely cant figure out any other way to do this, the infobox keeps replicating itself when hopping worlds
+                infoBoxManager.addInfoBox(specOverlayCounter);
+            }
+        }
 
     }
 


### PR DESCRIPTION
I've added an option to always show the special attack infobox, regardless of the weapon. I had created a plugin for this purpose, but was directed to contribute to this plugin rather than adding a new plugin to the plugin hub.